### PR TITLE
Comment line blocking module update

### DIFF
--- a/membership_users/membership_users.py
+++ b/membership_users/membership_users.py
@@ -129,5 +129,5 @@ class GroupsView(orm.Model):
             xml_content = etree.tostring(
                 xml, pretty_print=True, xml_declaration=True, encoding="utf-8"
             )
-            view.write({'arch': xml_content})
+#            view.write({'arch': xml_content})
         return res


### PR DESCRIPTION
This line block the migration process when we update all the modules, until we really debug this feature it's best to disactivate it.
